### PR TITLE
cleanup lightning system

### DIFF
--- a/src/core/action.cpp
+++ b/src/core/action.cpp
@@ -6,6 +6,9 @@
 #include "core/camera/camera_controller.h"
 #include "core/component/components.h"
 #include "core/factory/factory.h"
+#include "core/system/render.h"
+#include "core/system/lightning.h"
+
 #include "core/system/input/input.h"
 #include "core/system/render.h"
 
@@ -39,11 +42,14 @@ void createScene()
     EntityFactory::createPlane(Vector3{ 0.f, 1.f, 0.f }, 0.f);
 
     // New light entities
-    const Shader& shader = RenderSystem::getSystem().getGeometryShader();
-    EntityFactory::createLight(shader, LIGHT_DIRECTIONAL, Vector3{ 20.f, 70.f, 0.f }, Vector3Zero(), WHITE);
-    EntityFactory::createLight(shader, LIGHT_SPOT, Vector3{ -2.f, 2.f, -2.f }, Vector3Zero(), WHITE, CAMERA_PERSPECTIVE);
-    EntityFactory::createLight(shader, LIGHT_POINT, Vector3{ 2.f, 1.f, 2.f }, Vector3Zero(), YELLOW, CAMERA_ORTHOGRAPHIC, 0.f);
-}
+    const   Shader& shader = RenderSystem::getSystem().getGeometryShader();
+    auto    const   lights = {
+        EntityFactory::createLight(shader, LIGHT_DIRECTIONAL, Vector3{ 20.f, 70.f, 0.f }, Vector3Zero(), WHITE),
+        EntityFactory::createLight(shader, LIGHT_SPOT, Vector3{ -2.f, 2.f, -2.f }, Vector3Zero(), WHITE, CAMERA_PERSPECTIVE),
+        EntityFactory::createLight(shader, LIGHT_POINT, Vector3{ 2.f, 1.f, 2.f }, Vector3Zero(), YELLOW, CAMERA_ORTHOGRAPHIC, 0.f),
+    };
+    LightningSystem::getSystem().setCurrentLightId(lights.begin()[0]);
+}   
 
 void throwBallFromCamera()
 {

--- a/src/core/component/components.h
+++ b/src/core/component/components.h
@@ -16,7 +16,6 @@ struct RenderComponent
 struct LightComponent
 {
     Light light;
-    int lightId;
     Camera caster;
 };
 

--- a/src/core/factory/factory.cpp
+++ b/src/core/factory/factory.cpp
@@ -161,9 +161,6 @@ entt::entity EntityFactory::createLight(Shader shader, int type, Vector3 positio
     lightComponent.caster.fovy = 90.9f;
     lightComponent.caster.projection = casterProjType;
  
-    static int lightId = 0;
-    lightComponent.lightId = lightId++;
-
     // Create entity and emplace components
     entt::registry& registry = EntityRegistry::getRegistry();
     entt::entity entity = registry.create();

--- a/src/core/system/lightning.cpp
+++ b/src/core/system/lightning.cpp
@@ -4,45 +4,15 @@
 
 #include "core/component/components.h"
 
-LightningSystem::LightningSystem(size_t id) 
+void LightningSystem::setCurrentLightId(entt::entity lightId)
 {
+    auto const&     entityView = getRegistry().view<LightComponent>(entt::exclude<DestroyTag>);
+    m_currentLight  = entityView.contains(lightId)
+                    ? lightId : m_currentLight;
 }
 
-void LightningSystem::update(float dt) 
-{
-    auto& entityView = getRegistry().view<LightComponent>(entt::exclude<DestroyTag>);
-
-    int lightsCount = 0;
-    for (auto entity : entityView) 
-    {
-        auto& lightComponent = entityView.get<LightComponent>(entity);
-
-        auto it = m_lightsMask.find(lightComponent.lightId);
-        lightComponent.light.enabled = (it != m_lightsMask.end()) ? it->second : false;
-        
-        if (lightComponent.light.enabled)
-        {
-            m_shadowCaster = lightComponent.caster;
-        }
-
-        lightComponent.light.position = lightComponent.caster.position;
-        lightComponent.light.target = lightComponent.caster.target;
-                
-        UpdateLightValues(m_shader, lightComponent.light);
-
-        ++lightsCount;
-    }
-
-    assert(lightsCount <= maxLights);
-}
-
-void LightningSystem::setLightEnable(int lightId, bool enable)
-{
-    m_lightsMask[lightId] = enable;
-}
-
-Matrix LightningSystem::getLightMatrix() const
-{
-    return MatrixMultiply(GetCameraMatrix(m_shadowCaster),
-        (m_shadowCaster.projection == CAMERA_PERSPECTIVE) ? CameraFrustum(m_shadowCaster) : CameraOrtho(m_shadowCaster));
+LightComponent const& LightningSystem::getCurrentLight() const {
+    auto&   entityView = getRegistry().view<LightComponent>(entt::exclude<DestroyTag>);
+    assert(entityView.contains(m_currentLight));
+    return  entityView.get<LightComponent>(m_currentLight);
 }

--- a/src/core/system/lightning.h
+++ b/src/core/system/lightning.h
@@ -2,25 +2,20 @@
 #include "system_base.h"
 #include "raylib.h"
 
+struct LightComponent;
+
 class LightningSystem : public SystemBase<LightningSystem>
 {
     SANDBOX3D_SYSTEM_CLASS(LightningSystem);
 public:
-    const static int maxLights = SANDBOX3D_MAX_LIGHTS;
-
-    void update(float dt);
-
-    void setLightEnable(int lightId, bool enable);
-    void setShader(Shader& shader) { m_shader = shader; }
-
-    Camera getShadowCaster() const { return m_shadowCaster; }
-    Matrix getLightMatrix() const;
+    void                    setCurrentLightId   (entt::entity lightId);
+    entt::entity            getCurrentLightId   () const { return m_currentLight; }
+    LightComponent const&   getCurrentLight     () const;
 
 protected:
-    LightningSystem(size_t id);
+    LightningSystem (size_t _) {}
+    void update     (float dt) {}
 
 private:
-    Shader m_shader;
-    Camera m_shadowCaster;
-    std::map<int, bool> m_lightsMask;
+    entt::entity m_currentLight = entt::entity(-1);
 };

--- a/src/core/system/render.h
+++ b/src/core/system/render.h
@@ -15,6 +15,8 @@ class RenderSystem : public SystemBase<RenderSystem>
     SANDBOX3D_SYSTEM_CLASS(RenderSystem);
     friend struct SystemDebugger<RenderSystem>;
 public:
+    static auto constexpr k_ambientColor = { 0.4f, 0.4f, 0.4f, 1.0f };
+
     void update(float dt);
 
     const ShadowMap& getShadowMap() { return m_shadowMap; }

--- a/src/graphics/lights.cpp
+++ b/src/graphics/lights.cpp
@@ -129,7 +129,9 @@ Light CreateLight(Shader shader, int type, Vector3 position, Vector3 target, Col
 {
 	Light light = { 0 };
 
-	if (lightsCount < SANDBOX3D_MAX_LIGHTS)
+	assert(lightsCount < SANDBOX3D_MAX_LIGHTS);
+	++lightsCount;
+
 	{
 		light.enabled = true;
 		light.type = type;
@@ -150,26 +152,24 @@ Light CreateLight(Shader shader, int type, Vector3 position, Vector3 target, Col
 		char spotSoftnessName[32] = "lights[x].spotSoftness\0";
 
 		// Set location name [x] depending on lights count
-		enabledName[7] = '0' + lightsCount;
-		typeName[7] = '0' + lightsCount;
-		posName[7] = '0' + lightsCount;
-		targetName[7] = '0' + lightsCount;
-		colorName[7] = '0' + lightsCount;
-		cutoffName[7] = '0' + lightsCount;
-		lightRadiusName[7] = '0' + lightsCount;
-		spotSoftnessName[7] = '0' + lightsCount;
+		// @NOTE: for now, only one light can be active at the time; offset ignored
+		enabledName             [7] = '0'; // + lightsCount;
+		typeName                [7] = '0'; // + lightsCount;
+		posName                 [7] = '0'; // + lightsCount;
+		targetName              [7] = '0'; // + lightsCount;
+		colorName               [7] = '0'; // + lightsCount;
+		cutoffName              [7] = '0'; // + lightsCount;
+		lightRadiusName         [7] = '0'; // + lightsCount;
+		spotSoftnessName        [7] = '0'; // + lightsCount;
 
-		light.enabledLoc = GetShaderLocation(shader, enabledName);
-		light.typeLoc = GetShaderLocation(shader, typeName);
-		light.posLoc = GetShaderLocation(shader, posName);
-		light.targetLoc = GetShaderLocation(shader, targetName);
-		light.colorLoc = GetShaderLocation(shader, colorName);
-		light.cutoffLoc = GetShaderLocation(shader, cutoffName);
-		light.lightRadiusLoc = GetShaderLocation(shader, lightRadiusName);
-		light.spotSoftnessLoc = GetShaderLocation(shader, spotSoftnessName);
-
-		UpdateLightValues(shader, light);
-		++lightsCount;
+		light.enabledLoc        = GetShaderLocation(shader, enabledName);
+		light.typeLoc           = GetShaderLocation(shader, typeName);
+		light.posLoc            = GetShaderLocation(shader, posName);
+		light.targetLoc         = GetShaderLocation(shader, targetName);
+		light.colorLoc          = GetShaderLocation(shader, colorName);
+		light.cutoffLoc         = GetShaderLocation(shader, cutoffName);
+		light.lightRadiusLoc    = GetShaderLocation(shader, lightRadiusName);
+		light.spotSoftnessLoc   = GetShaderLocation(shader, spotSoftnessName);
 	}
 	return light;
 }


### PR DESCRIPTION
- use only one light source at once
- use entity id as a light id
- move light to shadow caster sync to render system
- drop unnecessary lightning system update